### PR TITLE
Fix 802.14.5 manifest revision update guard

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -89,9 +89,7 @@ runs:
         diff -B west.yml tmp.yml | patch west.yml - || true
 
     - name: Change west.yml nrf-802154 revision
-      if: |
-        startsWith(github.event.pull_request.title, 'nrf_802154: Update revision of nrf_802154') && 
-        github.event.action == 'opened'
+      if: ${{ startsWith(github.event.pull_request.title, 'nrf_802154: Update revision of nrf_802154') && github.event.action == 'opened' }}
       env:
         COMMITS_URL: ${{ github.event.pull_request.commits_url }}
       shell: bash


### PR DESCRIPTION
The previous format caused updating the 802.15.4 revision even if the title did not match.
See
https://github.com/nrfconnect/sdk-nrf/pull/14789