### PR TITLE
Fix: un-matched quotation mark in PR title fails `pr-create`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,13 +119,14 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}
+        MANIFEST_PR_TITLE: ${{ inputs.manifest-pr-title-details }}
       run: |
         git checkout -b manifest_pr
         git add west.yml
         git commit -m "manifest: Update ${{ github.event.repository.name }} revision (auto-manifest PR)" -m "Automatically created by Github Action" --signoff
         git remote add fork https://nordicbuilder:${{ inputs.token }}@github.com/${{ inputs.forked-repo }}
         git push -u fork manifest_pr:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
-        gh pr create --base main --repo ${{ inputs.target-repo }} --title "manifest: ${{ github.event.repository.name }}: ${{ inputs.manifest-pr-title-details }}" \
+        gh pr create --base main --repo ${{ inputs.target-repo }} --title "manifest: ${{ github.event.repository.name }}: $MANIFEST_PR_TITLE" \
           --body "Automatically created by action-manifest-pr GH action from PR: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
 
 # Checkout phase for retrigger CI or update west.yml from PR to sha


### PR DESCRIPTION
If PR title contains " then this action failed. Attempting to patch action.