### PR TITLE
Add head parameter to gh pr create

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -133,7 +133,9 @@ runs:
         git commit -m "manifest: Update ${{ github.event.repository.name }} revision (auto-manifest PR)" -m "Automatically created by Github Action" --signoff
         git remote add fork https://nordicbuilder:${{ inputs.token }}@github.com/${{ inputs.forked-repo }}
         git push -u fork manifest_pr:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
-        gh pr create --base ${{ inputs.base-branch }} --repo ${{ inputs.target-repo }} --title "manifest: ${{ github.event.repository.name }}: $MANIFEST_PR_TITLE" \
+        USERNAME=$(echo "${{ inputs.forked-repo }}" | cut -d'/' -f1)
+        gh pr create --head "$USERNAME:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}" \
+          --base ${{ inputs.base-branch }} --repo ${{ inputs.target-repo }} --title "manifest: ${{ github.event.repository.name }}: $MANIFEST_PR_TITLE" \
           --body "Automatically created by action-manifest-pr GH action from PR: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
 
 # Checkout phase for retrigger CI or update west.yml from PR to sha


### PR DESCRIPTION
Manifest PR creation has started failing for unknown reason it fails to detect head automatically. This will fix the problem.