### PR TITLE
fix: skip dragoon and nrf-802154 updates when absent from west.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ Action is self-cancelling itself in case of this string is found from PR title o
 
 ## draft PR:
 By default, the manifest PR is created as a ready-for-review PR. To create it as a draft PR, set the `draft-pr` input to `true`.
+
+## nrfxlib manifest PR side-effect updates
+
+When this action runs from **sdk-nrfxlib** (or another triggering repo), the manifest PR normally updates only that repo's `west.yml` entry. For certain nrfxlib PR titles, the action also updates additional manifest projects—**but only if those projects are present in the target branch's `west.yml`**.
+
+| Triggering PR title prefix | `west.yml` project updated | Notes |
+|---|---|---|
+| `Update MPSL and SoftDevice Controller` | `dragoon` | Revision is taken from the third word of the triggering PR's latest commit message. Skipped when `dragoon` is not in `west.yml` (e.g. some starlight branches). |
+| `Update revision of nrf_802154` | `nrf-802154` (802.15.4) | Same commit-message parsing as dragoon. Skipped when `nrf-802154` is not in `west.yml`. |
+
+In all cases the action still updates the triggering repository's own `repo-path` entry to `pull/<nr>/head` as usual.

--- a/action.yml
+++ b/action.yml
@@ -102,8 +102,19 @@ runs:
         yq ".manifest.projects[$PROJECT_KEY].revision = \"pull/${{ github.event.pull_request.number }}/head\"" west.yml > tmp.yml
         diff -B west.yml tmp.yml | patch west.yml - || true
 
+    - name: Check dragoon project in west.yml
+      id: dragoon_check
+      if: ${{ startsWith(github.event.pull_request.title, 'Update MPSL and SoftDevice Controller') && github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true' }}
+      shell: bash
+      run: |
+        if yq '.manifest.projects[] | select(.name == "dragoon")' west.yml | grep -q .; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Change west.yml Dragoon revision
-      if: ${{ startsWith(github.event.pull_request.title, 'Update MPSL and SoftDevice Controller') && github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true'}}
+      if: ${{ startsWith(github.event.pull_request.title, 'Update MPSL and SoftDevice Controller') && github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true' && steps.dragoon_check.outputs.exists == 'true' }}
       env:
         COMMITS_URL: ${{ github.event.pull_request.commits_url }}
       shell: bash
@@ -118,8 +129,19 @@ runs:
         yq ".manifest.projects[$PROJECT_KEY].revision = \"$DRAGOON_REV\"" west.yml > tmp.yml
         diff -B west.yml tmp.yml | patch west.yml - || true
 
-    - name: Change west.yml nrf-802154 revision
+    - name: Check nrf-802154 project in west.yml
+      id: nrf802154_check
       if: ${{ startsWith(github.event.pull_request.title, 'Update revision of nrf_802154') && github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true' }}
+      shell: bash
+      run: |
+        if yq '.manifest.projects[] | select(.name == "nrf-802154")' west.yml | grep -q .; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Change west.yml nrf-802154 revision
+      if: ${{ startsWith(github.event.pull_request.title, 'Update revision of nrf_802154') && github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true' && steps.nrf802154_check.outputs.exists == 'true' }}
       env:
         COMMITS_URL: ${{ github.event.pull_request.commits_url }}
       shell: bash


### PR DESCRIPTION
## Summary
- Guard dragoon and nrf-802154 west.yml revision steps with existence checks before running yq
- Document nrfxlib side-effect manifest updates in README

## Test plan
- [ ] Verify MPSL nrfxlib PR on a branch without `dragoon` in west.yml no longer fails with `Error: no matches found`
- [ ] Verify dragoon/nrf-802154 revisions still update when those projects are present