### PR TITLE
refactor!: rewrite manifest PR handler from bash to Python

### DIFF
--- a/.github/requirements.in
+++ b/.github/requirements.in
@@ -1,0 +1,6 @@
+-r ../requirements.txt
+mypy
+pytest
+ruff
+types-PyYAML
+types-requests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,26 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: .github/requirements.in
+      - run: pip install -r requirements.txt -r .github/requirements.in
+      - run: ruff check .
+      - run: mypy action.py west.py
+      - run: pytest test/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+.venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+tmp.yml

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+line-length = 100
+target-version = "py310"
+
+[lint]
+select = [
+    "B",
+    "E",
+    "F",
+    "I",
+    "SIM",
+    "UP",
+    "W",
+]
+
+ignore = [
+    "SIM108",
+]
+
+[format]
+quote-style = "preserve"
+line-ending = "lf"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # action-manifest-pr
 GitHub action to automatically create Pull Requests in the manifest repo when updating revisions.
 
+Implementation follows the same pattern as [zephyrproject-rtos/action-manifest](https://github.com/zephyrproject-rtos/action-manifest): a composite action that installs Python dependencies and runs `action.py`.
+
 ## usage
 Please call this action from triggering repo to create manifest PRs automatically (e.g. sdk-nrfxlib)
 ```yaml
@@ -28,3 +30,43 @@ Action is self-cancelling itself in case of this string is found from PR title o
 
 ## draft PR:
 By default, the manifest PR is created as a ready-for-review PR. To create it as a draft PR, set the `draft-pr` input to `true`.
+
+## nrfxlib manifest PR side-effect updates
+
+When this action runs from **sdk-nrfxlib** (or another triggering repo), the manifest PR normally updates only that repo's `west.yml` entry. For certain nrfxlib PR titles, the action also updates additional manifest projects—**but only if those projects are present in the target branch's `west.yml`**.
+
+| Triggering PR title prefix | `west.yml` project updated | Notes |
+|---|---|---|
+| `Update MPSL and SoftDevice Controller` | `dragoon` | Revision is taken from the third word of the triggering PR's latest commit message. Skipped when `dragoon` is not in `west.yml` (e.g. some starlight branches). |
+| `Update revision of nrf_802154` | `nrf-802154` (802.15.4) | Same commit-message parsing as dragoon. Skipped when `nrf-802154` is not in `west.yml`. |
+
+In all cases the action still updates the triggering repository's own `repo-path` entry to `pull/<nr>/head` as usual.
+
+## implementation
+
+| File | Role |
+|---|---|
+| `action.yml` | Composite wrapper: external-label check, `pip install`, run `action.py` |
+| `action.py` | Entry point: reads the GitHub event, orchestrates git/gh operations |
+| `west.py` | `west.yml` lookup and revision updates |
+| `requirements.txt` | Runtime Python dependencies |
+
+Event handling in `action.py`:
+
+- **opened** — check out the manifest repo, update `west.yml`, push a branch to the fork, open a manifest PR
+- **synchronize** — rebase the manifest PR branch to retrigger CI
+- **closed** (merged) — replace `pull/N/head` with the merge commit SHA
+- **closed** (not merged) — close the manifest PR
+- **reopened** — reopen the manifest PR
+
+## development
+
+```bash
+pip install -r requirements.txt
+pip install -r .github/requirements.in
+pytest test/
+ruff check .
+mypy .
+```
+
+CI runs ruff, mypy, and pytest on every push and pull request (see `.github/workflows/ci.yaml`).

--- a/action.py
+++ b/action.py
@@ -200,16 +200,22 @@ def update_west_for_opened(
     west_mod.set_project_revision(west_file, project_key, f'pull/{pr_number}/head')
 
     if title.startswith(DRAGOON_TITLE_PREFIX):
-        message = fetch_last_commit_message(token, pull_request.get('commits_url'))
-        dragoon_rev = west_mod.parse_revision_from_commit_message(message)
-        log(f'DRAGOON_REV is {dragoon_rev}')
-        west_mod.set_project_revision_by_name(west_file, 'dragoon', dragoon_rev)
+        if west_mod.has_project(west_file, 'dragoon'):
+            message = fetch_last_commit_message(token, pull_request.get('commits_url'))
+            dragoon_rev = west_mod.parse_revision_from_commit_message(message)
+            log(f'DRAGOON_REV is {dragoon_rev}')
+            west_mod.set_project_revision_by_name(west_file, 'dragoon', dragoon_rev)
+        else:
+            log('dragoon not found in west.yml, skipping revision update')
 
     if title.startswith(NRF802154_TITLE_PREFIX):
-        message = fetch_last_commit_message(token, pull_request.get('commits_url'))
-        nrf_rev = west_mod.parse_revision_from_commit_message(message)
-        log(f'NRF_802154_REV is {nrf_rev}')
-        west_mod.set_project_revision_by_name(west_file, 'nrf-802154', nrf_rev)
+        if west_mod.has_project(west_file, 'nrf-802154'):
+            message = fetch_last_commit_message(token, pull_request.get('commits_url'))
+            nrf_rev = west_mod.parse_revision_from_commit_message(message)
+            log(f'NRF_802154_REV is {nrf_rev}')
+            west_mod.set_project_revision_by_name(west_file, 'nrf-802154', nrf_rev)
+        else:
+            log('nrf-802154 not found in west.yml, skipping revision update')
 
 
 def handle_opened(args: argparse.Namespace, event: dict, token: str) -> None:

--- a/action.py
+++ b/action.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import NoReturn
+
+import requests
+
+import west as west_mod
+
+DRAGOON_TITLE_PREFIX = 'Update MPSL and SoftDevice Controller'
+NRF802154_TITLE_PREFIX = 'Update revision of nrf_802154'
+WEST_FILE = 'west.yml'
+
+_logging = 0
+
+
+def log(message: str) -> None:
+    if _logging:
+        print(message, file=sys.stdout)
+
+
+def die(message: str) -> NoReturn:
+    print(f'ERROR: {message}', file=sys.stderr)
+    sys.exit(1)
+
+
+def cmd2str(cmd: tuple[str, ...]) -> str:
+    return ' '.join(shlex.quote(word) for word in cmd)
+
+
+def git(*args: str, cwd: Path | None = None) -> str:
+    git_cmd = ('git',) + args
+    log(f'Executing git cmd {git_cmd}')
+    try:
+        process = subprocess.Popen(
+            git_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=cwd,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"failed to run '{cmd2str(git_cmd)}': {exc}") from exc
+
+    stdout, stderr = process.communicate()
+    stdout_text = stdout.decode('utf-8')
+    stderr_text = stderr.decode('utf-8')
+    if process.returncode or stderr_text:
+        die(
+            f"'{cmd2str(git_cmd)}' exited with status {process.returncode} and/or wrote "
+            f'to stderr.\n==stdout==\n{stdout_text}\n==stderr==\n{stderr_text}'
+        )
+    return stdout_text.rstrip()
+
+
+def gh(*args: str, cwd: Path | None = None) -> str:
+    gh_cmd = ('gh',) + args
+    log(f'Executing gh cmd {gh_cmd}')
+    try:
+        process = subprocess.run(
+            gh_cmd,
+            capture_output=True,
+            cwd=cwd,
+            check=False,
+            text=True,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"failed to run '{cmd2str(gh_cmd)}': {exc}") from exc
+
+    if process.returncode:
+        die(
+            f"'{cmd2str(gh_cmd)}' exited with status {process.returncode}.\n"
+            f'==stdout==\n{process.stdout}\n==stderr==\n{process.stderr}'
+        )
+    return process.stdout.rstrip()
+
+
+def require_token() -> str:
+    token = os.environ.get('GITHUB_TOKEN') or os.environ.get('GH_TOKEN')
+    if not token:
+        die('GITHUB_TOKEN or GH_TOKEN is required')
+    return token
+
+
+def load_event() -> dict:
+    event_path = os.environ.get('GITHUB_EVENT_PATH')
+    if not event_path:
+        die('GITHUB_EVENT_PATH is not set')
+    path = Path(event_path)
+    with path.open(encoding='utf-8') as fh:
+        return json.load(fh)
+
+
+def skip_string_detected(event: dict, skip_string: str) -> bool:
+    pull_request = event.get('pull_request', {})
+    title = pull_request.get('title', '')
+    body = pull_request.get('body') or ''
+    return skip_string in title or skip_string in body
+
+
+def check_external_contribution(token: str, repository: str, pr_number: int) -> None:
+    labels = gh(
+        'pr',
+        'view',
+        str(pr_number),
+        '--repo',
+        repository,
+        '--json',
+        'labels',
+        '--jq',
+        '.labels[].name',
+    )
+    if 'external' not in labels.splitlines():
+        return
+
+    author_json = gh(
+        'pr',
+        'view',
+        str(pr_number),
+        '--repo',
+        repository,
+        '--json',
+        'author',
+        '--jq',
+        '.author',
+    )
+    author = json.loads(author_json)
+    if author.get('login') == 'app/github-actions' and author.get('is_bot'):
+        log('Author is GitHub Actions bot, skipping external contribution check.')
+        return
+
+    die(
+        'External contribution detected. Automatic creation of manifest PR failed.\n'
+        'To test your changes, please create PR in the sdk-nrf repository.'
+    )
+
+
+def setup_git() -> None:
+    git('config', '--global', 'user.email', 'pylon@nordicsemi.no')
+    git('config', '--global', 'user.name', 'Nordic Builder')
+
+
+def clone_repo(token: str, repo: str, destination: Path, branch: str | None = None) -> Path:
+    destination.mkdir(parents=True, exist_ok=True)
+    url = f'https://x-access-token:{token}@github.com/{repo}.git'
+    git('clone', url, str(destination))
+    if branch is not None:
+        git('checkout', branch, cwd=destination)
+    return destination
+
+
+def manifest_branch_name(repo_name: str, pr_number: int) -> str:
+    return f'auto-manifest-{repo_name}-{pr_number}'
+
+
+def pr_body(source_repository: str, pr_number: int) -> str:
+    return (
+        'Automatically created by action-manifest-pr GH action from PR:\n'
+        f'https://github.com/{source_repository}/pull/{pr_number}'
+    )
+
+
+def fetch_last_commit_message(token: str, commits_url: str | None) -> str:
+    if not commits_url:
+        die('commits_url is missing from pull request event')
+    response = requests.get(
+        f'{commits_url}?per_page=3',
+        headers={'Authorization': f'token {token}'},
+        timeout=60,
+    )
+    response.raise_for_status()
+    commits = response.json()
+    if not commits:
+        die('No commits found on pull request')
+    return commits[-1]['commit']['message']
+
+
+def update_west_for_opened(
+    west_file: Path,
+    event: dict,
+    token: str,
+) -> None:
+    pull_request = event['pull_request']
+    repo_name = event['repository']['name']
+    pr_number = pull_request['number']
+    title = pull_request['title']
+
+    project_key = west_mod.project_key_by_repo_path(west_file, repo_name)
+    west_mod.set_project_revision(west_file, project_key, f'pull/{pr_number}/head')
+
+    if title.startswith(DRAGOON_TITLE_PREFIX):
+        message = fetch_last_commit_message(token, pull_request.get('commits_url'))
+        dragoon_rev = west_mod.parse_revision_from_commit_message(message)
+        log(f'DRAGOON_REV is {dragoon_rev}')
+        west_mod.set_project_revision_by_name(west_file, 'dragoon', dragoon_rev)
+
+    if title.startswith(NRF802154_TITLE_PREFIX):
+        message = fetch_last_commit_message(token, pull_request.get('commits_url'))
+        nrf_rev = west_mod.parse_revision_from_commit_message(message)
+        log(f'NRF_802154_REV is {nrf_rev}')
+        west_mod.set_project_revision_by_name(west_file, 'nrf-802154', nrf_rev)
+
+
+def handle_opened(args: argparse.Namespace, event: dict, token: str) -> None:
+    pull_request = event['pull_request']
+    repo_name = event['repository']['name']
+    source_repository = event['repository']['full_name']
+    pr_number = pull_request['number']
+    fork_username = args.forked_repo.split('/', maxsplit=1)[0]
+    branch_name = manifest_branch_name(repo_name, pr_number)
+    body = pr_body(source_repository, pr_number)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_dir = clone_repo(token, args.target_repo, Path(tmp) / 'manifest', args.base_branch)
+        west_file = repo_dir / WEST_FILE
+        update_west_for_opened(west_file, event, token)
+
+        git('checkout', '-b', 'manifest_pr', cwd=repo_dir)
+        git('add', WEST_FILE, cwd=repo_dir)
+        git(
+            'commit',
+            '-m',
+            f'manifest: Update {repo_name} revision (auto-manifest PR)',
+            '-m',
+            body,
+            '--signoff',
+            cwd=repo_dir,
+        )
+        fork_url = f'https://x-access-token:{token}@github.com/{args.forked_repo}'
+        git('remote', 'add', 'fork', fork_url, cwd=repo_dir)
+        git('push', '-u', 'fork', f'manifest_pr:{branch_name}', cwd=repo_dir)
+
+    draft_args = ('--draft',) if args.draft_pr else ()
+    gh(
+        'pr',
+        'create',
+        '--head',
+        f'{fork_username}:{branch_name}',
+        '--base',
+        args.base_branch,
+        '--repo',
+        args.target_repo,
+        '--title',
+        f'manifest: {repo_name}: {args.manifest_pr_title_details}',
+        '--body',
+        body,
+        *draft_args,
+    )
+
+
+def handle_synchronize(args: argparse.Namespace, event: dict, token: str) -> None:
+    pull_request = event['pull_request']
+    repo_name = event['repository']['name']
+    pr_number = pull_request['number']
+    branch_name = manifest_branch_name(repo_name, pr_number)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_dir = clone_repo(token, args.forked_repo, Path(tmp) / 'fork', branch_name)
+        git('remote', 'add', 'upstream', f'https://github.com/{args.target_repo}.git', cwd=repo_dir)
+        git('fetch', 'upstream', cwd=repo_dir)
+        git('rebase', f'upstream/{args.base_branch}', '-X', 'theirs', cwd=repo_dir)
+        git('commit', '--amend', '--no-edit', cwd=repo_dir)
+        git('push', 'origin', f'{branch_name}:{branch_name}', '-f', cwd=repo_dir)
+
+
+def handle_merged(args: argparse.Namespace, event: dict, token: str) -> None:
+    pull_request = event['pull_request']
+    repo_name = event['repository']['name']
+    pr_number = pull_request['number']
+    branch_name = manifest_branch_name(repo_name, pr_number)
+    merge_sha = pull_request['merge_commit_sha']
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_dir = clone_repo(token, args.forked_repo, Path(tmp) / 'fork', branch_name)
+        west_file = repo_dir / WEST_FILE
+        project_key = west_mod.project_key_by_repo_path(west_file, repo_name)
+        west_mod.set_project_revision(west_file, project_key, merge_sha)
+
+        git('add', WEST_FILE, cwd=repo_dir)
+        git('commit', '--amend', '--no-edit', cwd=repo_dir)
+        git('remote', 'add', 'upstream', f'https://github.com/{args.target_repo}.git', cwd=repo_dir)
+        git('fetch', 'upstream', cwd=repo_dir)
+
+        merge_tree = subprocess.run(
+            (
+                'git',
+                'merge-tree',
+                '--write-tree',
+                '--name-only',
+                f'upstream/{args.base_branch}',
+                branch_name,
+            ),
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        log(f'has_conflict is {merge_tree.returncode}')
+        if merge_tree.returncode == 1:
+            git('rebase', f'upstream/{args.base_branch}', '-X', 'theirs', cwd=repo_dir)
+        git('push', 'origin', f'{branch_name}:{branch_name}', '-f', cwd=repo_dir)
+
+
+def gh_optional(*args: str) -> None:
+    gh_cmd = ('gh',) + args
+    subprocess.run(gh_cmd, check=False)
+
+
+def handle_closed(args: argparse.Namespace, event: dict) -> None:
+    pull_request = event['pull_request']
+    repo_name = event['repository']['name']
+    pr_number = pull_request['number']
+    branch_name = manifest_branch_name(repo_name, pr_number)
+    gh_optional(
+        'pr',
+        'close',
+        '-R',
+        args.target_repo,
+        f'NordicBuilder:{branch_name}',
+        '--comment',
+        'Automatically closed by action-manifest-pr GH action',
+    )
+
+
+def handle_reopened(args: argparse.Namespace, event: dict) -> None:
+    pull_request = event['pull_request']
+    repo_name = event['repository']['name']
+    pr_number = pull_request['number']
+    branch_name = manifest_branch_name(repo_name, pr_number)
+    gh_optional(
+        'pr',
+        'reopen',
+        '-R',
+        args.target_repo,
+        f'NordicBuilder:{branch_name}',
+        '--comment',
+        'Automatically reopened by action-manifest-pr GH action',
+    )
+
+
+def main() -> None:
+    global _logging
+
+    parser = argparse.ArgumentParser(
+        description='Create and manage manifest PRs from triggering repo PRs',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('--target-repo', default='nrfconnect/sdk-nrf')
+    parser.add_argument('--base-branch', default='main')
+    parser.add_argument('--forked-repo', default='nordicbuilder/sdk-nrf')
+    parser.add_argument('--skip-string', default='manifest-pr-skip')
+    parser.add_argument('--manifest-pr-title-details', default='Update revision')
+    parser.add_argument('--draft-pr', action='store_true')
+    parser.add_argument('-v', '--verbosity-level', default='0')
+    args = parser.parse_args()
+    _logging = int(args.verbosity_level)
+
+    token = require_token()
+    os.environ['GH_TOKEN'] = token
+    os.environ['GITHUB_TOKEN'] = token
+
+    event = load_event()
+    if skip_string_detected(event, args.skip_string):
+        log('Skip string detected. Will skip following steps.')
+        return
+
+    repository = event['repository']['full_name']
+    pr_number = event['pull_request']['number']
+    check_external_contribution(token, repository, pr_number)
+
+    action = event['action']
+    pull_request = event['pull_request']
+
+    setup_git()
+
+    if action == 'opened':
+        handle_opened(args, event, token)
+    elif action == 'synchronize':
+        handle_synchronize(args, event, token)
+    elif action == 'closed':
+        if pull_request.get('merged'):
+            handle_merged(args, event, token)
+        else:
+            handle_closed(args, event)
+    elif action == 'reopened':
+        handle_reopened(args, event)
+    else:
+        log(f'No handler for action {action!r}')
+
+
+if __name__ == '__main__':
+    main()

--- a/action.yml
+++ b/action.yml
@@ -37,16 +37,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Skip string detection
-      id: check
-      if: contains(github.event.pull_request.title, inputs.skip-string ) ||
-        contains(github.event.pull_request.body, inputs.skip-string )
-      shell: bash
-      run: |
-        echo "Skip string detected. Will skip following steps."
-        echo "SKIP_STRING=true" >> "$GITHUB_OUTPUT"
-
-    # fail in case of external user
     - name: Add external label
       uses: carlescufi/action-contribs@main
       with:
@@ -54,164 +44,23 @@ runs:
         command: 'external'
         labels: 'external'
 
-    - name: Stop in case external label is set
+    - name: Setup Python
       shell: bash
       run: |
-        LABELS=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json labels --jq '.labels[].name')
+        pip3 install setuptools wheel
+        pip3 install -r "${{ github.action_path }}/requirements.txt"
 
-        if [[ "$LABELS" == *"external"* ]]; then
-          AUTHOR_INFO=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json author --jq '.author')
-          AUTHOR_LOGIN=$(echo "$AUTHOR_INFO" | jq -r '.login')
-          AUTHOR_IS_BOT=$(echo "$AUTHOR_INFO" | jq -r '.is_bot')
-
-          if [[ "$AUTHOR_LOGIN" == "app/github-actions" && "$AUTHOR_IS_BOT" == "true" ]]; then
-            echo "Author is GitHub Actions bot, skipping external contribution check."
-          else
-            echo "External contribution detected. Automatic creation of manifest PR failed."
-            echo "To test your changes, please create PR in the sdk-nrf repository."
-            exit 1
-          fi
-        fi
+    - name: Run manifest PR handler
+      shell: bash
       env:
+        GITHUB_TOKEN: ${{ inputs.token }}
         GH_TOKEN: ${{ inputs.token }}
-
-    # Common setup for all the phases
-    - name: Setup git
-      if: ${{ steps.check.outputs.SKIP_STRING != 'true' }}
-      shell: bash
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
       run: |
-        git config --global user.email "pylon@nordicsemi.no"
-        git config --global user.name "Nordic Builder"
-
-    # Checkout phase for manifest PR creation
-    - name: Checkout sources
-      if: ${{ github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true' }}
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ inputs.target-repo }}
-        token: ${{ inputs.token }}
-        ref: ${{ inputs.base-branch }}
-
-
-    # west.yml preparation for manifest PR creation
-    - name: Change west.yml PR revision
-      if: ${{ github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true' }}
-      shell: bash
-      run: |
-        PROJECT_KEY=$(yq --exit-status '.manifest.projects[] | select(.repo-path == "${{ github.event.repository.name }}") |  key' west.yml)
-        yq ".manifest.projects[$PROJECT_KEY].revision = \"pull/${{ github.event.pull_request.number }}/head\"" west.yml > tmp.yml
-        diff -B west.yml tmp.yml | patch west.yml - || true
-
-    - name: Change west.yml Dragoon revision
-      if: ${{ startsWith(github.event.pull_request.title, 'Update MPSL and SoftDevice Controller') && github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true'}}
-      env:
-        COMMITS_URL: ${{ github.event.pull_request.commits_url }}
-      shell: bash
-      run: |
-        if [ "${COMMITS_URL}x" != "x" ]; then
-          # API URL details: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-commits-on-a-pull-request
-          LAST_MSG=$(curl -H "Authorization: token ${{ inputs.token }}" "${COMMITS_URL}?per_page=3" | jq -r .[-1].commit.message)
-        fi
-        DRAGOON_REV=$(echo $LAST_MSG | awk 'NR==1 {print $3}' | head)
-        echo "DRAGOON_REV is $DRAGOON_REV"
-        PROJECT_KEY=$(yq --exit-status '.manifest.projects[] | select(.name == "dragoon") |  key' west.yml)
-        yq ".manifest.projects[$PROJECT_KEY].revision = \"$DRAGOON_REV\"" west.yml > tmp.yml
-        diff -B west.yml tmp.yml | patch west.yml - || true
-
-    - name: Change west.yml nrf-802154 revision
-      if: ${{ startsWith(github.event.pull_request.title, 'Update revision of nrf_802154') && github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true' }}
-      env:
-        COMMITS_URL: ${{ github.event.pull_request.commits_url }}
-      shell: bash
-      run: |
-        if [ "${COMMITS_URL}x" != "x" ]; then
-          # API URL details: https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-commits-on-a-pull-request
-          LAST_MSG=$(curl -H "Authorization: token ${{ inputs.token }}" "${COMMITS_URL}?per_page=3" | jq -r .[-1].commit.message)
-        fi
-        NRF_802154_REV=$(echo $LAST_MSG | awk 'NR==1 {print $3}' | head)
-        echo "NRF_802154_REV is $NRF_802154_REV"
-        PROJECT_KEY=$(yq --exit-status '.manifest.projects[] | select(.name == "nrf-802154") |  key' west.yml)
-        yq ".manifest.projects[$PROJECT_KEY].revision = \"$NRF_802154_REV\"" west.yml > tmp.yml
-        diff -B west.yml tmp.yml | patch west.yml - || true
-
-    # create actual manifest PR
-    - name: Commit changed west.yml and create PR
-      if: ${{ github.event.action == 'opened' && steps.check.outputs.SKIP_STRING != 'true' }}
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.token }}
-        MANIFEST_PR_TITLE: ${{ inputs.manifest-pr-title-details }}
-        BODY: |
-           Automatically created by action-manifest-pr GH action from PR:
-           https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-
-      run: |
-        git checkout -b manifest_pr
-        git add west.yml
-        git commit -m "manifest: Update ${{ github.event.repository.name }} revision (auto-manifest PR)" -m "$BODY" --signoff
-        git remote add fork "https://nordicbuilder:${{ inputs.token }}@github.com/${{ inputs.forked-repo }}"
-        git push -u fork manifest_pr:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
-        USERNAME=$(echo "${{ inputs.forked-repo }}" | cut -d'/' -f1)
-        gh pr create --head "$USERNAME:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}" \
-          --base ${{ inputs.base-branch }} --repo ${{ inputs.target-repo }} --title "manifest: ${{ github.event.repository.name }}: $MANIFEST_PR_TITLE" \
-          --body "$BODY" ${{ inputs.draft-pr == 'true' && '--draft' || '' }}
-
-    # Checkout phase for retrigger CI or update west.yml from PR to sha
-    - name: Checkout sources from fork
-      if: ${{ (github.event.action == 'synchronize' || github.event.pull_request.merged == true) && steps.check.outputs.SKIP_STRING != 'true' }}
-      uses: actions/checkout@v4
-      with:
-        repository: ${{ inputs.forked-repo }}
-        token: ${{ inputs.token }}
-        fetch-depth: 0
-
-    # This is used for retriggering CI in case sub-PR got updates (assumes manifest PR exists)
-    - name: Retrigger CI by changing commit sha and pushing
-      if: ${{ github.event.action == 'synchronize' && steps.check.outputs.SKIP_STRING != 'true' }}
-      shell: bash
-      run: |
-        git checkout auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
-        git remote add upstream https://github.com/${{ inputs.target-repo }}
-        git fetch upstream
-        git rebase upstream/${{ inputs.base-branch }} -X theirs
-        git commit --amend --no-edit
-        git push origin auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }} -f
-
-    # This is used for changing PR pointer to sha in west.yml (assumes manifest PR exists)
-    - name: Change commit sha and push it
-      if: ${{ github.event.pull_request.merged == true && steps.check.outputs.SKIP_STRING != 'true' }}
-      shell: bash
-      run: |
-        git checkout auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
-        PROJECT_KEY=$(yq --exit-status '.manifest.projects[] | select(.repo-path == "${{ github.event.repository.name }}") |  key' west.yml)
-        yq ".manifest.projects[$PROJECT_KEY].revision = \"${{ github.event.pull_request.merge_commit_sha }}\"" west.yml > tmp.yml
-        diff -B west.yml tmp.yml | patch west.yml - || true
-        git add west.yml
-        git commit --amend --no-edit
-        git remote add upstream https://github.com/${{ inputs.target-repo }}
-        git fetch upstream
-        set +e
-        git merge-tree --write-tree --name-only upstream/${{ inputs.base-branch }} auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
-        has_conflict="$?"
-        echo "has_conflict is" $has_conflict
-        set -e
-        if (( $has_conflict == 1)) ; then git rebase upstream/${{ inputs.base-branch }} -X theirs ; fi
-        git push origin auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }}:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }} -f
-
-    - name: Close manifest-PR upon closing PR
-      if: ${{ github.event.action == 'closed' && github.event.pull_request.merged == false && steps.check.outputs.SKIP_STRING != 'true'}}
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.token }}
-      run: |
-        gh pr close -R ${{ inputs.target-repo }} NordicBuilder:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }} \
-          --comment "Automatically closed by action-manifest-pr GH action" || true
-
-    - name: Re-open  manifest-PR upon reopening PR
-      if: ${{ github.event.action == 'reopened' && steps.check.outputs.SKIP_STRING != 'true'}}
-      shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.token }}
-      run: |
-        gh pr reopen -R ${{ inputs.target-repo }} NordicBuilder:auto-manifest-${{ github.event.repository.name }}-${{ github.event.pull_request.number }} \
-          --comment "Automatically reopened by action-manifest-pr GH action" || true
+        python3 "${{ github.action_path }}/action.py" \
+          --target-repo "${{ inputs.target-repo }}" \
+          --base-branch "${{ inputs.base-branch }}" \
+          --forked-repo "${{ inputs.forked-repo }}" \
+          --skip-string "${{ inputs.skip-string }}" \
+          --manifest-pr-title-details "${{ inputs.manifest-pr-title-details }}" \
+          ${{ inputs.draft-pr == 'true' && '--draft-pr' || '' }}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+ruamel.yaml

--- a/test/fixtures/west-full.yml
+++ b/test/fixtures/west-full.yml
@@ -1,0 +1,9 @@
+manifest:
+  projects:
+    - name: sdk-nrfxlib-starlight
+      repo-path: sdk-nrfxlib-starlight
+      revision: main
+    - name: dragoon
+      revision: abc123
+    - name: nrf-802154
+      revision: def456

--- a/test/fixtures/west-no-dragoon.yml
+++ b/test/fixtures/west-no-dragoon.yml
@@ -1,0 +1,5 @@
+manifest:
+  projects:
+    - name: sdk-nrfxlib-starlight
+      repo-path: sdk-nrfxlib-starlight
+      revision: main

--- a/test/fixtures/west-no-nrf802154.yml
+++ b/test/fixtures/west-no-nrf802154.yml
@@ -1,0 +1,7 @@
+manifest:
+  projects:
+    - name: sdk-nrfxlib-starlight
+      repo-path: sdk-nrfxlib-starlight
+      revision: main
+    - name: dragoon
+      revision: abc123

--- a/test/test_west.py
+++ b/test/test_west.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+from ruamel.yaml import YAML
+
+import west
+from west import WestProjectNotFoundError
+
+FIXTURES = Path(__file__).parent / 'fixtures'
+
+
+@pytest.fixture
+def west_file(tmp_path: Path) -> Path:
+    return tmp_path / 'west.yml'
+
+
+def copy_fixture(west_file: Path, fixture_name: str) -> None:
+    shutil.copy(FIXTURES / fixture_name, west_file)
+
+
+def read_revision(west_file: Path, index: int) -> str:
+    yaml = YAML()
+    with west_file.open(encoding='utf-8') as fh:
+        data = yaml.load(fh)
+    return data['manifest']['projects'][index]['revision']
+
+
+def test_project_key_by_repo_path_finds_correct_index(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-full.yml')
+    assert west.project_key_by_repo_path(west_file, 'sdk-nrfxlib-starlight') == 0
+
+
+def test_project_key_by_name_finds_dragoon(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-full.yml')
+    assert west.project_key_by_name(west_file, 'dragoon') == 1
+
+
+def test_project_key_by_name_finds_nrf802154(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-full.yml')
+    assert west.project_key_by_name(west_file, 'nrf-802154') == 2
+
+
+def test_project_key_by_name_returns_none_when_project_absent(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-no-dragoon.yml')
+    assert west.project_key_by_name(west_file, 'dragoon') is None
+
+
+def test_set_project_revision_updates_revision(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-full.yml')
+    west.set_project_revision(west_file, 0, 'pull/42/head')
+    assert read_revision(west_file, 0) == 'pull/42/head'
+
+
+def test_parse_revision_from_commit_message() -> None:
+    message = 'Update revision d0b7c6f56ef62ae49d4cd4c5befc006621fee5c1 for MPSL'
+    assert west.parse_revision_from_commit_message(message) == (
+        'd0b7c6f56ef62ae49d4cd4c5befc006621fee5c1'
+    )
+
+
+def test_set_project_revision_by_name_updates_dragoon_when_present(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-full.yml')
+    west.set_project_revision_by_name(west_file, 'dragoon', 'deadbeef')
+    assert read_revision(west_file, 1) == 'deadbeef'
+
+
+def test_set_project_revision_by_name_raises_when_dragoon_absent(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-no-dragoon.yml')
+    with pytest.raises(WestProjectNotFoundError):
+        west.set_project_revision_by_name(west_file, 'dragoon', 'deadbeef')

--- a/test/test_west.py
+++ b/test/test_west.py
@@ -7,7 +7,6 @@ import pytest
 from ruamel.yaml import YAML
 
 import west
-from west import WestProjectNotFoundError
 
 FIXTURES = Path(__file__).parent / 'fixtures'
 
@@ -61,13 +60,29 @@ def test_parse_revision_from_commit_message() -> None:
     )
 
 
+def test_has_project_returns_true_when_dragoon_exists(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-full.yml')
+    assert west.has_project(west_file, 'dragoon') is True
+
+
+def test_has_project_returns_false_when_dragoon_absent(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-no-dragoon.yml')
+    assert west.has_project(west_file, 'dragoon') is False
+
+
 def test_set_project_revision_by_name_updates_dragoon_when_present(west_file: Path) -> None:
     copy_fixture(west_file, 'west-full.yml')
-    west.set_project_revision_by_name(west_file, 'dragoon', 'deadbeef')
+    assert west.set_project_revision_by_name(west_file, 'dragoon', 'deadbeef') is True
     assert read_revision(west_file, 1) == 'deadbeef'
 
 
-def test_set_project_revision_by_name_raises_when_dragoon_absent(west_file: Path) -> None:
+def test_set_project_revision_by_name_skips_when_dragoon_absent(west_file: Path) -> None:
     copy_fixture(west_file, 'west-no-dragoon.yml')
-    with pytest.raises(WestProjectNotFoundError):
-        west.set_project_revision_by_name(west_file, 'dragoon', 'deadbeef')
+    assert west.set_project_revision_by_name(west_file, 'dragoon', 'deadbeef') is False
+    assert read_revision(west_file, 0) == 'main'
+
+
+def test_set_project_revision_by_name_skips_when_nrf802154_absent(west_file: Path) -> None:
+    copy_fixture(west_file, 'west-no-nrf802154.yml')
+    assert west.set_project_revision_by_name(west_file, 'nrf-802154', 'deadbeef') is False
+    assert read_revision(west_file, 1) == 'abc123'

--- a/west.py
+++ b/west.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+_yaml = YAML()
+_yaml.preserve_quotes = True
+_yaml.width = 4096
+
+
+class WestProjectNotFoundError(LookupError):
+    pass
+
+
+def _load(west_file: Path) -> dict:
+    with west_file.open(encoding='utf-8') as fh:
+        data = _yaml.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f'{west_file} is not a mapping')
+    return data
+
+
+def _save(west_file: Path, data: dict) -> None:
+    with west_file.open('w', encoding='utf-8') as fh:
+        _yaml.dump(data, fh)
+
+
+def _projects(west_file: Path) -> list:
+    return _load(west_file)['manifest']['projects']
+
+
+def project_key_by_name(west_file: Path, name: str) -> int | None:
+    for index, project in enumerate(_projects(west_file)):
+        if project.get('name') == name:
+            return index
+    return None
+
+
+def project_key_by_repo_path(west_file: Path, repo_path: str) -> int:
+    for index, project in enumerate(_projects(west_file)):
+        if project.get('repo-path') == repo_path:
+            return index
+    raise WestProjectNotFoundError(f'repo-path {repo_path!r} not found in {west_file}')
+
+
+def set_project_revision(west_file: Path, project_key: int, revision: str) -> None:
+    data = _load(west_file)
+    data['manifest']['projects'][project_key]['revision'] = revision
+    _save(west_file, data)
+
+
+def set_project_revision_by_name(west_file: Path, name: str, revision: str) -> None:
+    project_key = project_key_by_name(west_file, name)
+    if project_key is None:
+        raise WestProjectNotFoundError(f'project {name!r} not found in {west_file}')
+    set_project_revision(west_file, project_key, revision)
+
+
+def parse_revision_from_commit_message(message: str) -> str:
+    return message.split('\n', maxsplit=1)[0].split()[2]

--- a/west.py
+++ b/west.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 from ruamel.yaml import YAML
@@ -54,11 +55,20 @@ def set_project_revision(west_file: Path, project_key: int, revision: str) -> No
     _save(west_file, data)
 
 
-def set_project_revision_by_name(west_file: Path, name: str, revision: str) -> None:
+def has_project(west_file: Path, name: str) -> bool:
+    return project_key_by_name(west_file, name) is not None
+
+
+def set_project_revision_by_name(west_file: Path, name: str, revision: str) -> bool:
     project_key = project_key_by_name(west_file, name)
     if project_key is None:
-        raise WestProjectNotFoundError(f'project {name!r} not found in {west_file}')
+        print(
+            f"Project '{name}' not found in {west_file}, skipping revision update.",
+            file=sys.stderr,
+        )
+        return False
     set_project_revision(west_file, project_key, revision)
+    return True
 
 
 def parse_revision_from_commit_message(message: str) -> str:


### PR DESCRIPTION
## Summary
- Migrate the composite action to a zephyr-style `action.py` entry point with `west.py` helpers
- Add pytest coverage, ruff/mypy CI, and updated README documentation
- Include dragoon/nrf-802154 skip guards in the Python implementation

Depends on #25 landing first (same guard logic, applied here in Python).

## Test plan
- [ ] CI passes (ruff, mypy, pytest)
- [ ] `./test/run.sh` equivalent: `pytest test/ -v`
- [ ] Smoke-test manifest PR creation after merge

## Breaking change
The action now requires pip-installed Python dependencies at runtime instead of shell-only yq and inline bash steps.